### PR TITLE
Add Redux to application

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "spotify_web_client",
       "version": "0.1.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^1.7.1",
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",
@@ -15,9 +16,12 @@
         "@types/node": "^16.11.19",
         "@types/react": "^17.0.38",
         "@types/react-dom": "^17.0.11",
+        "@types/react-redux": "^7.1.22",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-redux": "^7.2.6",
         "react-scripts": "5.0.0",
+        "redux": "^4.1.2",
         "typescript": "^4.5.4",
         "web-vitals": "^2.1.3"
       }
@@ -2666,6 +2670,29 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.7.1.tgz",
+      "integrity": "sha512-wXwXYjBVz/ItxB7SMzEAMmEE/FBiY1ze18N+VVVX7NtVbRUrdOGKhpQMHivIJfkbJvSdLUU923a/yAagJQzY0Q==",
+      "dependencies": {
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || 18.0.0-beta",
+        "react-redux": "^7.2.1 || ^8.0.0-beta"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz",
@@ -3334,6 +3361,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -3443,6 +3479,17 @@
       "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-redux": {
+      "version": "7.1.22",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.22.tgz",
+      "integrity": "sha512-GxIA1kM7ClU73I6wg9IRTVwSO9GS+SAKZKe0Enj+82HMU6aoESFU2HNAdNi3+J53IaOHPiUfT3kSG4L828joDQ==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -7835,6 +7882,19 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hoopy": {
       "version": "0.1.4",
@@ -12995,6 +13055,30 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "node_modules/react-redux": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
+      "integrity": "sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -13120,6 +13204,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
+      "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "peerDependencies": {
+        "redux": "^4"
       }
     },
     "node_modules/regenerate": {
@@ -13262,6 +13362,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "node_modules/reselect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.5.tgz",
+      "integrity": "sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ=="
     },
     "node_modules/resolve": {
       "version": "1.21.0",
@@ -17668,6 +17773,17 @@
         }
       }
     },
+    "@reduxjs/toolkit": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.7.1.tgz",
+      "integrity": "sha512-wXwXYjBVz/ItxB7SMzEAMmEE/FBiY1ze18N+VVVX7NtVbRUrdOGKhpQMHivIJfkbJvSdLUU923a/yAagJQzY0Q==",
+      "requires": {
+        "immer": "^9.0.7",
+        "redux": "^4.1.2",
+        "redux-thunk": "^2.4.1",
+        "reselect": "^4.1.5"
+      }
+    },
     "@rollup/plugin-babel": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz",
@@ -18143,6 +18259,15 @@
         "@types/node": "*"
       }
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -18252,6 +18377,17 @@
       "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/react-redux": {
+      "version": "7.1.22",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.22.tgz",
+      "integrity": "sha512-GxIA1kM7ClU73I6wg9IRTVwSO9GS+SAKZKe0Enj+82HMU6aoESFU2HNAdNi3+J53IaOHPiUfT3kSG4L828joDQ==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "@types/resolve": {
@@ -21488,6 +21624,21 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
     },
     "hoopy": {
       "version": "0.1.4",
@@ -25100,6 +25251,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "react-redux": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.6.tgz",
+      "integrity": "sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
+      }
+    },
     "react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -25194,6 +25358,20 @@
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
       }
+    },
+    "redux": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
+      "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "redux-thunk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "requires": {}
     },
     "regenerate": {
       "version": "1.4.2",
@@ -25304,6 +25482,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "reselect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.5.tgz",
+      "integrity": "sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ=="
     },
     "resolve": {
       "version": "1.21.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@reduxjs/toolkit": "^1.7.1",
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
@@ -10,9 +11,12 @@
     "@types/node": "^16.11.19",
     "@types/react": "^17.0.38",
     "@types/react-dom": "^17.0.11",
+    "@types/react-redux": "^7.1.22",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-redux": "^7.2.6",
     "react-scripts": "5.0.0",
+    "redux": "^4.1.2",
     "typescript": "^4.5.4",
     "web-vitals": "^2.1.3"
   },

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen } from './test-utils'
 import App from './App';
 
 test('renders learn react link', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import logo from './logo.svg';
 import './App.css';
 import WebPlayback from './components/WebPlayBack';
+import Counter from './components/Counter'
 
 function App() {
   return (
@@ -20,6 +21,7 @@ function App() {
         >
           Learn React
         </a>
+        <Counter></Counter>
       </header>
     </div>
   );

--- a/src/components/Counter.tsx
+++ b/src/components/Counter.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { useAppDispatch } from '../hooks/useAppDispatch'
+import { useAppSelector } from '../hooks/useAppSelector'
+import { decrement, increment } from '../store/counterSlice'
+
+function Counter() {
+
+  const counter = useAppSelector((state) => state.counter.value)
+  const dispatch = useAppDispatch()
+
+  const handleDecrement = () => {
+    dispatch(decrement())
+  }
+  const handleIncrement = () => {
+    dispatch(increment())
+  }
+
+  return (
+    <div>
+      <button onClick={handleDecrement}>-</button>
+      {counter}
+      <button onClick={handleIncrement}>+</button>
+    </div>
+  )
+}
+
+export default Counter

--- a/src/components/Counter.tsx
+++ b/src/components/Counter.tsx
@@ -3,6 +3,16 @@ import { useAppDispatch } from '../hooks/useAppDispatch'
 import { useAppSelector } from '../hooks/useAppSelector'
 import { decrement, increment } from '../store/counterSlice'
 
+
+/**
+ * The counter component is a temporary component to demonstrate how
+ * the Redux store can be accessed and how an action can be dispatched
+ * from a component
+ * 
+ * Counter uses the decrement and increment actions to increment
+ * and decrement the global counter value and reads that value from
+ * the redux store using a selector
+ */
 function Counter() {
 
   const counter = useAppSelector((state) => state.counter.value)

--- a/src/hooks/useAppDispatch.ts
+++ b/src/hooks/useAppDispatch.ts
@@ -1,0 +1,4 @@
+import { useDispatch } from 'react-redux'
+import type { AppDispatch } from '../store'
+
+export const useAppDispatch = () => useDispatch<AppDispatch>()

--- a/src/hooks/useAppDispatch.ts
+++ b/src/hooks/useAppDispatch.ts
@@ -1,4 +1,9 @@
 import { useDispatch } from 'react-redux'
 import type { AppDispatch } from '../store'
 
+/**
+ * Returns a wrapper around useDispatch that sets the generic
+ * type to our AppDispatch type so that TypeScript can infer
+ * the type when we dispatch actions
+ */
 export const useAppDispatch = () => useDispatch<AppDispatch>()

--- a/src/hooks/useAppSelector.ts
+++ b/src/hooks/useAppSelector.ts
@@ -1,0 +1,4 @@
+import { TypedUseSelectorHook, useSelector } from 'react-redux'
+import type { RootState } from '../store'
+
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector

--- a/src/hooks/useAppSelector.ts
+++ b/src/hooks/useAppSelector.ts
@@ -1,4 +1,9 @@
 import { TypedUseSelectorHook, useSelector } from 'react-redux'
 import type { RootState } from '../store'
 
+/**
+ * Types the useSelector hook to use our RootState type
+ * for the generic. This will allow TypeScript to infer the type
+ * of our state when we write selectors
+ */
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,10 +3,14 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { Provider } from 'react-redux';
+import store from './store'
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </React.StrictMode>,
   document.getElementById('root')
 );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,11 @@ import reportWebVitals from './reportWebVitals';
 import { Provider } from 'react-redux';
 import store from './store'
 
+/**
+ * This is the entry point for our application. Here we wrap our App
+ * component in a Redux Provider so that our store can be accessed
+ * from anywhere in the app
+ */
 ReactDOM.render(
   <React.StrictMode>
     <Provider store={store}>

--- a/src/store/__tests__/counterSlice.test.ts
+++ b/src/store/__tests__/counterSlice.test.ts
@@ -1,0 +1,50 @@
+import reducer, { CounterState, increment, decrement, reset } from "../counterSlice"
+
+
+const previousState: CounterState = {
+  value: 10,
+  resetCounter: 1
+}
+
+
+describe('#increment', () => {
+  it('should return updated state with incremented value', () => {
+    const expected: CounterState = {
+      value: 11,
+      resetCounter: 1
+    }
+
+    const actual = reducer(previousState, increment())
+
+    expect(actual).toEqual(expected)
+    expect(actual).not.toBe(previousState)
+  })
+})
+
+describe('#decrement', () => {
+  it('should return updated state with decremented value', () => {
+    const expected: CounterState = {
+      value: 9,
+      resetCounter: 1
+    }
+
+    const actual = reducer(previousState, decrement())
+
+    expect(actual).toEqual(expected)
+    expect(actual).not.toBe(previousState)
+  })
+})
+
+describe('#reset', () => {
+  it('should return updated state with reset value and incremented reset counter', () => {
+    const expected: CounterState = {
+      value: 0,
+      resetCounter: 2
+    }
+
+    const actual = reducer(previousState, reset())
+
+    expect(actual).toEqual(expected)
+    expect(actual).not.toBe(previousState)
+  })
+})

--- a/src/store/__tests__/counterSlice.test.ts
+++ b/src/store/__tests__/counterSlice.test.ts
@@ -1,5 +1,8 @@
 import reducer, { CounterState, increment, decrement, reset } from "../counterSlice"
 
+/**
+ * Test file for our counter slice
+ */
 
 const previousState: CounterState = {
   value: 10,

--- a/src/store/counterSlice.ts
+++ b/src/store/counterSlice.ts
@@ -1,0 +1,34 @@
+import { createSlice } from '@reduxjs/toolkit'
+
+interface CounterState {
+  value: number
+  resetCounter: number
+}
+
+const initialState = {
+  value: 0,
+  resetCounter: 0
+} as CounterState
+
+const counterSlice = createSlice({
+  name: 'counter',
+  initialState: initialState,
+  reducers: {
+    increment: (state) => ({
+      ...state,
+      value: state.value + 1
+    }),
+    decrement: (state) => ({
+      ...state,
+      value: state.value - 1
+    }),
+    reset: (state) => ({
+      value: 0,
+      resetCounter: state.resetCounter + 1
+    })
+  }
+})
+
+export const { increment, decrement, reset } = counterSlice.actions
+export type { CounterState }
+export default counterSlice.reducer

--- a/src/store/counterSlice.ts
+++ b/src/store/counterSlice.ts
@@ -5,11 +5,22 @@ interface CounterState {
   resetCounter: number
 }
 
+/**
+ * Initial counter state
+ * 
+ * We create the counter with an initial value of 0 and an
+ * initial resetCounter value of 0
+ */
 const initialState = {
   value: 0,
   resetCounter: 0
 } as CounterState
 
+/**
+ * Creates a slice that holds the initial state needed for our Counter
+ * as well as defining how increment, decrement, and reset actions will
+ * return us a new state
+ */
 const counterSlice = createSlice({
   name: 'counter',
   initialState: initialState,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,13 @@
+import { configureStore } from '@reduxjs/toolkit'
+import counterSlice from './counterSlice'
+
+
+const store = configureStore({
+  reducer: {
+    counter: counterSlice
+  }
+})
+
+export type RootState = ReturnType<typeof store.getState>
+export type AppDispatch = typeof store.dispatch
+export default store

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,13 +1,17 @@
-import { configureStore } from '@reduxjs/toolkit'
+import { combineReducers, configureStore } from '@reduxjs/toolkit'
 import counterSlice from './counterSlice'
 
+const reducer = combineReducers({
+  counter: counterSlice
+})
 
 const store = configureStore({
-  reducer: {
-    counter: counterSlice
-  }
+  reducer
 })
+
+const initialRootState = store.getState()
 
 export type RootState = ReturnType<typeof store.getState>
 export type AppDispatch = typeof store.dispatch
+export { reducer, initialRootState }
 export default store

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,14 +1,23 @@
 import { combineReducers, configureStore } from '@reduxjs/toolkit'
 import counterSlice from './counterSlice'
 
+/**
+ * Creates the root reducer that is a combination of all other reducers in our app
+ */
 const reducer = combineReducers({
   counter: counterSlice
 })
 
+/**
+ * Creates a store with our root reducer
+ */
 const store = configureStore({
   reducer
 })
 
+/**
+ * Gets the starting state so it can be exported and used for tests
+ */
 const initialRootState = store.getState()
 
 export type RootState = ReturnType<typeof store.getState>

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { render as rtlRender, RenderOptions } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import store, { initialRootState, RootState } from './store'
+
+interface StoreConfig extends RenderOptions {
+  preloadedState: RootState,
+  reduxStore: typeof store,
+}
+
+function render(
+  ui: React.ReactElement,
+  {
+    preloadedState,
+    reduxStore,
+    ...renderOptions
+  }: StoreConfig = {
+    preloadedState: initialRootState,
+    reduxStore: store
+  }
+): ReturnType<typeof rtlRender> {
+  function Wrapper({ children }: { children: React.ReactElement<any, string | React.JSXElementConstructor<any>>}) {
+    return <Provider store={store}>{children}</Provider>
+  }
+  return rtlRender(ui, { wrapper: Wrapper, ...renderOptions })
+}
+
+export * from '@testing-library/react'
+export { render }

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -8,6 +8,15 @@ interface StoreConfig extends RenderOptions {
   reduxStore: typeof store,
 }
 
+/**
+ * Wraps the react-testing-library render function to automatically
+ * wrap any component with a Provider so that they can access an actual
+ * implementation of our Redux store from tests
+ * 
+ * This will make it much easier to write tests for components that depend
+ * on redux because we will not have to worry about setting up a mock
+ * provider for each component
+ */
 function render(
   ui: React.ReactElement,
   {


### PR DESCRIPTION
This PR adds Redux to our application. Redux will be used for global state management going forward

A temporary counter component was also added to the application as well as a test utility to wrap the react-testing-library render method with our redux store automatically

The changes here are based on the getting started guides on the redux and redux toolkit websites
https://redux.js.org/usage/usage-with-typescript
https://redux-toolkit.js.org/usage/usage-with-typescript

This closes #8 