### PR TITLE
fix: Remove invalid field from search request

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -74,7 +74,7 @@ app.get('/api/v1/auth/token', (req, res) => {
 
 app.get('/api/v1/search', (req, res) => {
   const search_query_parameters = new URLSearchParams({
-    type: 'album,artist,track,genre',
+    type: 'album,artist,track',
     ...req.query
   })
 


### PR DESCRIPTION
#30 contained an invalid field in the search query parameters. This PR removes that invalid field to fix our search component